### PR TITLE
Fix usage of error_messages parameter to override validation messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,27 @@
 
 version: 0.1.5
 
+## Usage:
+
+    from stdnumfield.models import StdNumField
+
+
+    class SomeMode(models.Model):
+        field = StdNumField(
+            'hr.oib',  # stdnum format
+        )
+
+
+    class SampleModelForm(ModelForm):
+        class Meta:
+            model = SomeModel
+            fields = ('field',)
+            error_messages = {
+                'field': {
+                    'stdnum_format':_("Not maching format %(format_list)s"),  # you can override exception message
+                },
+            }
+
 ## What's an stdnum?
 
 See [python-stdnum](https://arthurdejong.org/python-stdnum/doc/1.5/index.html)

--- a/stdnumfield/forms.py
+++ b/stdnumfield/forms.py
@@ -31,8 +31,6 @@ class StdnumField(forms.CharField):
                     ))
         self.formats = formats
         self.alphabets = alphabets
-
-    def validate(self, value):
-        super(StdnumField, self).validate(value)
-        validator = StdnumFormatValidator(self.formats, self.alphabets)
-        validator(value)
+        self.validators.append(
+            StdnumFormatValidator(self.formats, self.alphabets),
+        )

--- a/stdnumfield/testproject/testapp/forms.py
+++ b/stdnumfield/testproject/testapp/forms.py
@@ -1,8 +1,22 @@
 # coding=utf-8
+from django.forms import ModelForm
 from django.forms.forms import Form
 
 from stdnumfield.forms import StdnumField
 
+from .models import SomeModel
+
 
 class SampleForm(Form):
     oib = StdnumField(formats=['hr.oib'])
+
+
+class SampleModelForm(ModelForm):
+    class Meta:
+        model = SomeModel
+        fields = ('oib',)
+        error_messages = {
+            'oib': {
+                'stdnum_format': "Foo error message",
+            },
+        }

--- a/stdnumfield/testproject/testapp/tests.py
+++ b/stdnumfield/testproject/testapp/tests.py
@@ -26,6 +26,25 @@ class SampleFormViewTest(TestCase):
         self.assertEqual(response.url, '/success/')
 
 
+class SampleModelFormViewTest(TestCase):
+
+    def setUp(self):
+        self.c = Client()
+
+    def test_invalid_value(self):
+        response = self.c.post(path='/model_form/', data={'oib': INVALID_OIB})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            escape('Foo error message'),
+        )
+
+    def test_valid_value(self):
+        response = self.c.post(path='/model_form/', data={'oib': VALID_OIB})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/success/')
+
+
 class ModelFieldTests(TestCase):
 
     def setUp(self):

--- a/stdnumfield/testproject/testapp/urls.py
+++ b/stdnumfield/testproject/testapp/urls.py
@@ -6,11 +6,13 @@ except ImportError:
 
 from .views import (
     SampleFormView,
+    SampleModelFormView,
     SuccessView,
 )
 
 
 urlpatterns = [
     url(r'^sample_form/$', SampleFormView.as_view(), name='sample_form'),
+    url(r'^model_form/$', SampleModelFormView.as_view(), name='model_form'),
     url(r'^success/$', SuccessView.as_view(), name='success'),
 ]

--- a/stdnumfield/testproject/testapp/views.py
+++ b/stdnumfield/testproject/testapp/views.py
@@ -7,11 +7,19 @@ except ImportError:
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 
-from .forms import SampleForm
+from .forms import SampleForm, SampleModelForm
+from .models import SomeModel
 
 
 class SampleFormView(FormView):
     form_class = SampleForm
+    template_name = 'form.html'
+    success_url = reverse_lazy('success')
+
+
+class SampleModelFormView(FormView):
+    form_class = SampleModelForm
+    model = SomeModel
     template_name = 'form.html'
     success_url = reverse_lazy('success')
 

--- a/stdnumfield/tests/forms.py
+++ b/stdnumfield/tests/forms.py
@@ -4,6 +4,7 @@ try:
 except ImportError:
     from mock import patch
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from stdnumfield.forms import StdnumField
@@ -59,6 +60,19 @@ class FormFieldInitTest(TestCase):
             alphabets=['12345'],
         )
 
+    def test_error_message_override(self):
+        field = StdnumField(
+            formats='cz.dic',
+            error_messages={'stdnum_format': 'test_exception'},
+        )
+
+        self.assertRaisesRegexp(
+            ValidationError,
+            'test_exception',
+            field.clean,
+            '01234',
+        )
+
 
 class FormFieldValidateTest(TestCase):
     formats = ['hr.oib']
@@ -66,7 +80,7 @@ class FormFieldValidateTest(TestCase):
     @patch('stdnumfield.forms.StdnumFormatValidator')
     def test_validate(self, validator_class):
         field = StdnumField(formats=self.formats)
-        field.validate(VALID_OIB)
+        field.run_validators(VALID_OIB)
         validator_class.assert_called_once_with(self.formats, None)
         validator_instance = validator_class.return_value
         validator_instance.assert_called_once_with(VALID_OIB)

--- a/stdnumfield/validators.py
+++ b/stdnumfield/validators.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.template.defaultfilters import truncatechars
 from stdnum.exceptions import ValidationError as Stdnum_ValidationError
 from django.utils.deconstruct import deconstructible
+from django.utils.translation import ugettext_lazy as _
 
 from stdnumfield import settings
 from stdnumfield.utils import import_stdnum, listify
@@ -13,12 +14,20 @@ class StdnumFormatValidator(object):
     formats = []
     alphabets = None
     empty = (None, '')
+    code = 'stdnum_format'
+    message = _(
+        'Value does not match with any of the formats: "%(format_list)s"'
+    )
 
-    def __init__(self, formats, alphabets=None):
+    def __init__(self, formats, alphabets=None, message=None, code=None):
         if formats is not None:
             self.formats = listify(formats)
         if alphabets is not None:
             self.alphabets = listify(alphabets)
+        if message is not None:
+            self.message = message
+        if code is not None:
+            self.code = code
 
     def _get_formats(self):
         if not self.formats:
@@ -54,5 +63,7 @@ class StdnumFormatValidator(object):
                 else:
                     return
         raise ValidationError(
-            'Value does not match with any of the formats: "{}"'
-            .format(truncatechars(', '.join(self.formats), 30)))
+            self.message,
+            code=self.code,
+            params={'format_list': truncatechars(', '.join(self.formats), 30)},
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    django{_master,110,19}-py{35,34,27}
+    django{111,110,19}-py{35,34,27}
     lint
 skipsdist = true
 
@@ -9,6 +9,7 @@ whitelist_externals = bash
 deps =
     django19: {[django]1.9.x}
     django110: {[django]1.10.x}
+    django111: {[django]1.11.x}
     django_master: {[django]master}
     mock
     python-stdnum>=1.4,<1.5
@@ -29,5 +30,7 @@ commands =
        Django>=1.9.0,<1.10.0
 1.10.x  =
        Django>=1.10.0,<1.11.0
+1.11.x  =
+       Django>=1.11.0,<1.12.0
 master =
        https://github.com/django/django/tarball/master


### PR DESCRIPTION
This patch moves implementation of Fields and Validators closer to the original Django implementation. This change enables possibility to use `error_messages` parameter to override validation messages correctly.

Beside other things it implements this recommendation: https://docs.djangoproject.com/ko/1.11/ref/forms/validation/#raising-validationerror

It also fixes/updates Django versions in test configuration.